### PR TITLE
More intuitive deleting stacked elements

### DIFF
--- a/libs/css/change_form.css
+++ b/libs/css/change_form.css
@@ -166,6 +166,8 @@ tr {
 .stacked-inline-close {
     text-align: right;
     cursor: pointer;
+    float: right;
+    margin: 0 1% 1% 0;
 }
 
 .inline-related {

--- a/material/admin/templates/admin/edit_inline/stacked.html
+++ b/material/admin/templates/admin/edit_inline/stacked.html
@@ -14,7 +14,6 @@
       {% for inline_admin_form in inline_admin_formset %}
         <div class="inline-related card {% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}"
              id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
-          <div class="stacked-inline-close"><i class="material-icons">close</i></div>
           <h3>
             <b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b>&nbsp;
             <span class="inline_label">
@@ -57,6 +56,7 @@
           {% if inline_admin_form.fk_field %}
             {{ inline_admin_form.fk_field.field }}
           {% endif %}
+          <div class="stacked-inline-close deletelink waves-effect waves-light btn red">{% trans "Delete" %} <i class="material-icons right">delete_forever</i></div>
         </div>
       {% endfor %}
     </div>

--- a/material/admin/templates/admin/edit_inline/stacked.html
+++ b/material/admin/templates/admin/edit_inline/stacked.html
@@ -56,7 +56,7 @@
           {% if inline_admin_form.fk_field %}
             {{ inline_admin_form.fk_field.field }}
           {% endif %}
-          <div class="stacked-inline-close deletelink waves-effect waves-light btn red">{% trans "Delete" %} <i class="material-icons right">delete_forever</i></div>
+          <div class="stacked-inline-close btn red">{% trans "Delete" %} <i class="material-icons right">delete_forever</i></div>
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
The cross (x) icon in the stacked elements was not intuitive about its function. Instead I have placed a delete button in the bottom of the card.

Before:
![imagen](https://user-images.githubusercontent.com/10652313/72083424-17c59f80-3302-11ea-97ce-08188b464950.png)

Now:
![imagen](https://user-images.githubusercontent.com/10652313/72083286-d2a16d80-3301-11ea-983f-4f4d77bf1d69.png)

You still have to save to apply the delete.