### PR TITLE
Widget media broken link in Django 3

### DIFF
--- a/material/admin/widgets.py
+++ b/material/admin/widgets.py
@@ -13,7 +13,7 @@ class MaterialAdminDateWidget(widgets.AdminDateWidget):
     @property
     def media(self):
         return forms.Media(
-            js=['material/admin/js/widgets/TimeServerDiff.js', 'material/admin/js/widgets//DateInput.js'],
+            js=['material/admin/js/widgets/TimeServerDiff.js', 'material/admin/js/widgets/DateInput.js'],
             css={'all': ('material/admin/css/date-input.min.css',)}
         )
 


### PR DESCRIPTION
ValueError: Missing staticfiles manifest entry for 'material/admin/js/widgets//DateInput.js' in Django 3 + whitenoise when debug is False.
Removing extra slash from the link