### PR TITLE
Fix date handling

### DIFF
--- a/material/templates/admin/base_site.html
+++ b/material/templates/admin/base_site.html
@@ -103,7 +103,7 @@
     <script>
         var datepickerOptions = {
             autoClose: true,
-            defaultDate: true,
+            setDefaultDate: true,
             showClearBtn: true,
             i18n: {
                 cancel: '{% trans 'Cancel' %}',


### PR DESCRIPTION
In the datepicker the options aren't very well described in the
documentation. To get the following behavior:

- Parse the date input in the text field
- on open, use this date and navigate the calendar to it, displaying its
  value

One has to *not* set the `defaultDate` option and set the
`setDefaultDate` option. This is the intuitive behaviour for a date
picker.