### PR TITLE
Desktop: Remove infinite loop on scroll

### DIFF
--- a/material/static/material/admin/js/admin.js
+++ b/material/static/material/admin/js/admin.js
@@ -8,7 +8,7 @@
     $('.collapsible-body, .collapsible-header').on('mouseenter', function() {
         $('.scroll-pane').jScrollPane();
     });
-    $('#side-bar').on('mouseenter scroll', function() {
+    $('#side-bar').on('mouseenter', function() {
         $('.scroll-pane').jScrollPane();
     }).mouseleave(
         function() {

--- a/package/setup.py
+++ b/package/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-material-admin",
-    version="1.8.6",
+    version="1.8.7",
     license='MIT License',
     packages=find_packages(),
     author="Anton Maistrenko",


### PR DESCRIPTION
Generally Scroll event create infinite loop for jScrollPane on Desktop

```bash
jquery.min.js:2
Uncaught RangeError: Maximum call stack size exceeded
at String.replace (<anonymous>)
at ne (jquery.min.js:2:33253)
at w.fn.init.<anonymous> (jquery.min.js:2:34063)
at z (jquery.min.js:2:31902)
at w.fn.init.data (jquery.min.js:2:33969)
at HTMLDivElement.<anonymous> (jquery.jscrollpane.min.js:8:13855)
at Function.each (jquery.min.js:2:2573)
at w.fn.init.each (jquery.min.js:2:1240)
at w.fn.init.a.fn.jScrollPane (jquery.jscrollpane.min.js:8:13821)
at HTMLDivElement.<anonymous> (admin.js:12:27)
```

