### PR TITLE
Enclosure the side-wrapper div into a block

### DIFF
--- a/material/templates/admin/change_list.html
+++ b/material/templates/admin/change_list.html
@@ -47,6 +47,7 @@
       {% block pagination %}{% pagination cl %}{% endblock %}
       </form>
     </div>
+    {% block side_wrapper %}
     <div class="side-wrapper">
       <div id="changelist-form" class="card">
         {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
@@ -65,5 +66,6 @@
         {% endblock %}
       </div>
     </div>
+    {% endblock %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Enclosure the "side-wrapper" div in its own block makes it easier for developers to customize this part of the change_list template. Currently it is necessary to override the entire content block to do any customization in the side_wrapper