### PR TITLE
fix: Return app_dict as django does to allow display a single app adm…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,8 @@
 name: Upload Python Package
 
 on:
+  push:
+    branches: [ "master" ]
   release:
     types: [published]
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,36 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,3 +36,8 @@ jobs:
       run: python -m build package/
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: packages/
+  

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      run: python -m build
+      run: python -m build package/
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@
 .. .. |build|
 
 
-.. |pypi| image:: https://d25lcipzij17d.cloudfront.net/badge.svg?id=py&type=6&v=1.8.6&x2=0
-    :target: https://pypi.org/project/django-material-admin/
+.. |pypi| image:: https://github.com/godjangollc/django-material-admin/actions/workflows/python-publish.yml/badge.svg
+    :target: https://pypi.org/project/godjango-material-admin/
 .. |python| image:: https://img.shields.io/badge/python-3.4+-blue.svg
     :target: https://www.python.org/
 .. |django| image:: https://img.shields.io/badge/django-2.2+|3.2-mediumseagreen.svg

--- a/material/admin/sites.py
+++ b/material/admin/sites.py
@@ -143,9 +143,6 @@ class MaterialAdminSite(AdminSite):
                     'icon': getattr(apps.get_app_config(app_label), 'icon_name', None)
                     or MATERIAL_ADMIN_SITE['APP_ICONS'].get(app_label)
                 }
-
-        if label:
-            return app_dict.get(label)
         return app_dict
 
 

--- a/package/setup.py
+++ b/package/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 
 setup(
-    name="django-material-admin",
+    name="godjango-material-admin",
     version="1.8.6",
     license='MIT License',
     packages=find_packages(),


### PR DESCRIPTION
…in view

FIX ISSUE #170 
FIX ISSUE #173 

Removed two lines of code that make Django launch an error because the string doesn't allow string indexes, to match more closely Django behavior when handling the model_dicts  I removed the two lines in this commit.